### PR TITLE
Fix resolve_addr

### DIFF
--- a/tools/resolve_addr.py
+++ b/tools/resolve_addr.py
@@ -31,9 +31,12 @@ def parse_maps(maps_filename):
         toks = line.split()
         if len(toks) == 6:
             addrs, perms, off, dev, inode, path = toks
-        else:
-            assert len(toks) == 5
+        elif len(toks) == 5:
             addrs, perms, off, dev, inode = toks
+            path = ''
+        else:
+            assert len(toks) == 7
+            addrs, perms, off, t, inode, dev, msg = toks
             path = ''
         begin, end = [int(a, 16) for a in addrs.split('-')]
         if path not in base_addrs:


### PR DESCRIPTION
resolve_addr.py is a handy tool to convert the crashed address of solded binary to the offset in the original binary file. This PR fixes the problem that it fails to parse some /proc/pid/maps file.