### PR TITLE
Include cstdint for newer gcc

### DIFF
--- a/strtab_builder.h
+++ b/strtab_builder.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This PR fixes `strtab_builder.h` to explicitly include `cstdint`, which seems to be required to build sold on newer GCC.
